### PR TITLE
Remove dependance on environment variables during build

### DIFF
--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -1,13 +1,15 @@
 import { createGoogleOAuthConfig, getRequiredEnv } from "deno_kv_oauth/mod.ts";
 
-export const OAUTH_CONFIG = createGoogleOAuthConfig({
-  redirectUri: getRequiredEnv("ORIGIN") + "/oauth/callback",
-  scope: [
-    "openid",
-    "https://www.googleapis.com/auth/userinfo.email",
-    "https://www.googleapis.com/auth/userinfo.profile",
-  ],
-});
+export function createOauthConfig() {
+  return createGoogleOAuthConfig({
+    redirectUri: getRequiredEnv("ORIGIN") + "/oauth/callback",
+    scope: [
+      "openid",
+      "https://www.googleapis.com/auth/userinfo.email",
+      "https://www.googleapis.com/auth/userinfo.profile",
+    ],
+  });
+}
 
 export interface UserInfo {
   /** User ID */

--- a/routes/oauth/callback.ts
+++ b/routes/oauth/callback.ts
@@ -1,12 +1,12 @@
 import { Handlers } from "$fresh/server.ts";
 import { handleCallback } from "deno_kv_oauth/mod.ts";
-import { OAUTH_CONFIG, UserInfo } from "$lib/oauth.ts";
+import { createOauthConfig, UserInfo } from "$lib/oauth.ts";
 
 export const handler: Handlers = {
   async GET(req) {
     const { response, sessionId, tokens } = await handleCallback(
       req,
-      OAUTH_CONFIG,
+      createOauthConfig(),
     );
 
     const openid_response = await fetch(

--- a/routes/oauth/signin.ts
+++ b/routes/oauth/signin.ts
@@ -1,9 +1,9 @@
 import { Handlers } from "$fresh/server.ts";
 import { signIn } from "deno_kv_oauth/mod.ts";
-import { OAUTH_CONFIG } from "$lib/oauth.ts";
+import { createOauthConfig } from "$lib/oauth.ts";
 
 export const handler: Handlers = {
   async GET(req) {
-    return await signIn(req, OAUTH_CONFIG);
+    return await signIn(req, createOauthConfig());
   },
 };


### PR DESCRIPTION
This moves environment variables to be lazily loaded. (ie. put behind a function call instead of a global constant)